### PR TITLE
Restyled Card Views to have a Linear Layout

### DIFF
--- a/app/src/main/res/layout/cardview_fill.xml
+++ b/app/src/main/res/layout/cardview_fill.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto">
@@ -29,7 +30,8 @@
                 android:text="id"
                 style="@style/textColorSpecial"
                 android:textSize="12sp"
-                android:visibility="gone" />
+                android:visibility="gone"
+                tools:ignore="HardcodedText" />
 
             <!-- DATE -->
             <TextView
@@ -47,7 +49,8 @@
                 android:text="(Timestamp)"
                 style="@style/textColor"
                 android:textSize="20sp"
-                android:textStyle="bold"/>
+                android:textStyle="bold"
+                tools:ignore="HardcodedText" />
 
             <!-- COST -->
             <TextView
@@ -58,7 +61,8 @@
                 android:layout_marginTop="36sp"
                 android:text="(Cost)"
                 style="@style/textColor"
-                android:textSize="16sp"/>
+                android:textSize="16sp"
+                tools:ignore="HardcodedText" />
 
             <!-- FUEL TYPE -->
             <TextView
@@ -69,7 +73,8 @@
                 android:layout_marginTop="60sp"
                 android:text="(Petrol Filled, Gas Station)"
                 style="@style/textColorSpecial"
-                android:textSize="12sp"/>
+                android:textSize="12sp"
+                tools:ignore="HardcodedText" />
 
             <!-- LT PER 100 -->
             <TextView
@@ -80,7 +85,8 @@
                 android:layout_marginTop="80sp"
                 android:text="(x per 100 km)"
                 style="@style/textColorSpecial"
-                android:textSize="12sp"/>
+                android:textSize="12sp"
+                tools:ignore="HardcodedText" />
 
             <!-- BUTTONS -->
             <com.google.android.material.floatingactionbutton.FloatingActionButton

--- a/app/src/main/res/layout/cardview_fill.xml
+++ b/app/src/main/res/layout/cardview_fill.xml
@@ -16,109 +16,106 @@
         app:cardCornerRadius="10dp"
         app:cardElevation="5dp">
 
-        <RelativeLayout
+        <!-- CONTAINER -->
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:baselineAligned="false"
+            android:orientation="horizontal">
 
-            <!-- ID -->
-            <TextView
-                android:id="@+id/card_hidden_id"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="60sp"
-                android:text="id"
-                style="@style/textColorSpecial"
-                android:textSize="12sp"
-                android:visibility="gone"
-                tools:ignore="HardcodedText" />
+            <!-- LABELS -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="10dp"
+                android:layout_weight="1"
+                android:layout_marginBottom="10dp"
+                android:orientation="vertical">
 
-            <!-- DATE -->
-            <TextView
-                android:id="@+id/card_date"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentStart="true"
-                android:layout_marginStart="7dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginEnd="7dp"
-                android:layout_marginBottom="8dp"
-                android:ellipsize="end"
-                android:lines="1"
-                android:scrollHorizontally="true"
-                android:text="(Timestamp)"
-                style="@style/textColor"
-                android:textSize="20sp"
-                android:textStyle="bold"
-                tools:ignore="HardcodedText" />
+                <!-- ID -->
+                <TextView
+                    android:id="@+id/card_hidden_id"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="id"
+                    style="@style/textColorSpecial"
+                    android:textSize="12sp"
+                    android:visibility="gone"
+                    tools:ignore="HardcodedText" />
 
-            <!-- COST -->
-            <TextView
-                android:id="@+id/card_cost"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="36sp"
-                android:text="(Cost)"
-                style="@style/textColor"
-                android:textSize="16sp"
-                tools:ignore="HardcodedText" />
+                <!-- DATE -->
+                <TextView
+                    android:id="@+id/card_date"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(Timestamp)"
+                    style="@style/textColor"
+                    android:textSize="20sp"
+                    android:textStyle="bold"
+                    tools:ignore="HardcodedText" />
 
-            <!-- FUEL TYPE -->
-            <TextView
-                android:id="@+id/card_filled_petrol"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="60sp"
-                android:text="(Petrol Filled, Gas Station)"
-                style="@style/textColorSpecial"
-                android:textSize="12sp"
-                tools:ignore="HardcodedText" />
+                <!-- COST -->
+                <TextView
+                    android:id="@+id/card_cost"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(Cost)"
+                    style="@style/textColor"
+                    android:textSize="16sp"
+                    tools:ignore="HardcodedText" />
 
-            <!-- LT PER 100 -->
-            <TextView
-                android:id="@+id/card_lt_per_100"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="80sp"
-                android:text="(x per 100 km)"
-                style="@style/textColorSpecial"
-                android:textSize="12sp"
-                tools:ignore="HardcodedText" />
+                <!-- FUEL TYPE -->
+                <TextView
+                    android:id="@+id/card_filled_petrol"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(Petrol Filled, Gas Station)"
+                    style="@style/textColorSpecial"
+                    android:textSize="12sp"
+                    tools:ignore="HardcodedText" />
+
+                <!-- LT PER 100 -->
+                <TextView
+                    android:id="@+id/card_lt_per_100"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(x per 100 km)"
+                    style="@style/textColorSpecial"
+                    android:textSize="12sp"
+                    tools:ignore="HardcodedText" />
+            </LinearLayout>
 
             <!-- BUTTONS -->
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/card_buttonDelete"
+            <LinearLayout
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentBottom="true"
-                android:layout_marginEnd="65dp"
-                android:layout_marginBottom="21dp"
-                android:clickable="true"
-                android:scaleX="0.8"
-                android:scaleY="0.8"
-                app:backgroundTint="#FF0000"
-                app:srcCompat="@android:drawable/ic_menu_delete" />
+                android:layout_height="match_parent"
+                android:layout_weight="0"
+                android:layout_marginEnd="10dp"
+                android:gravity="center"
+                android:orientation="horizontal">
 
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/card_buttonEdit"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentBottom="true"
-                android:layout_marginEnd="9dp"
-                android:layout_marginBottom="21dp"
-                android:clickable="true"
-                android:scaleX="0.8"
-                android:scaleY="0.8"
-                app:backgroundTint="#3B89FF"
-                app:srcCompat="@android:drawable/ic_menu_edit" />
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/card_buttonDelete"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:scaleX="0.8"
+                    android:scaleY="0.8"
+                    app:backgroundTint="#FF0000"
+                    app:srcCompat="@android:drawable/ic_menu_delete" />
 
-        </RelativeLayout>
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/card_buttonEdit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:scaleX="0.8"
+                    android:scaleY="0.8"
+                    app:backgroundTint="#3B89FF"
+                    app:srcCompat="@android:drawable/ic_menu_edit" />
 
+            </LinearLayout>
+        </LinearLayout>
     </androidx.cardview.widget.CardView>
-
 </LinearLayout>

--- a/app/src/main/res/layout/cardview_fill_with_legend.xml
+++ b/app/src/main/res/layout/cardview_fill_with_legend.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:orientation="vertical">
 
     <!-- YEAR MONTH LEGEND -->
     <TextView
@@ -17,7 +17,8 @@
         android:text="mmmm YYYY"
         style="@style/textColor"
         android:textSize="24sp"
-        android:textStyle="bold"/>
+        android:textStyle="bold"
+        tools:ignore="HardcodedText" />
 
     <TextView
         android:id="@+id/card_cost_legend"
@@ -28,117 +29,10 @@
         android:layout_marginBottom="8dp"
         android:text="total cost"
         style="@style/textColorSpecial"
-        android:textSize="12sp"/>
+        android:textSize="12sp"
+        tools:ignore="HardcodedText" />
 
-    <androidx.cardview.widget.CardView
-        android:layout_width="match_parent"
-        android:layout_height="105dp"
-        android:layout_marginTop="5dp"
-        android:layout_marginBottom="10dp"
-        android:layout_marginStart="5dp"
-        android:layout_marginEnd="5dp"
-        style="@style/cardMainBackground"
-        app:cardCornerRadius="10dp"
-        app:cardElevation="5dp">
-
-        <RelativeLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
-
-            <!-- ID -->
-            <TextView
-                android:id="@+id/card_hidden_id"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="60sp"
-                android:text="id"
-                style="@style/textColorSpecial"
-                android:textSize="12sp"
-                android:visibility="gone" />
-
-            <!-- DATE -->
-            <TextView
-                android:id="@+id/card_date"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentStart="true"
-                android:layout_marginStart="7dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginEnd="7dp"
-                android:layout_marginBottom="8dp"
-                android:ellipsize="end"
-                android:lines="1"
-                android:scrollHorizontally="true"
-                android:text="(Timestamp)"
-                style="@style/textColor"
-                android:textSize="20sp"
-                android:textStyle="bold"/>
-
-            <!-- COST -->
-            <TextView
-                android:id="@+id/card_cost"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="36sp"
-                android:text="(Cost)"
-                style="@style/textColor"
-                android:textSize="16sp"/>
-
-            <!-- FUEL TYPE -->
-            <TextView
-                android:id="@+id/card_filled_petrol"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="60sp"
-                android:text="(Petrol Filled, Gas Station)"
-                style="@style/textColorSpecial"
-                android:textSize="12sp"/>
-
-            <!-- LT PER 100 -->
-            <TextView
-                android:id="@+id/card_lt_per_100"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="80sp"
-                android:text="(x per 100 km)"
-                style="@style/textColorSpecial"
-                android:textSize="12sp"/>
-
-            <!-- BUTTONS -->
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/card_buttonDelete"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentBottom="true"
-                android:layout_marginEnd="65dp"
-                android:layout_marginBottom="21dp"
-                android:clickable="true"
-                android:scaleX="0.8"
-                android:scaleY="0.8"
-                app:backgroundTint="#FF0000"
-                app:srcCompat="@android:drawable/ic_menu_delete" />
-
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/card_buttonEdit"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentBottom="true"
-                android:layout_marginEnd="9dp"
-                android:layout_marginBottom="21dp"
-                android:clickable="true"
-                android:scaleX="0.8"
-                android:scaleY="0.8"
-                app:backgroundTint="#3B89FF"
-                app:srcCompat="@android:drawable/ic_menu_edit" />
-
-        </RelativeLayout>
-
-    </androidx.cardview.widget.CardView>
+    <include
+        layout="@layout/cardview_fill" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/cardview_malfunction.xml
+++ b/app/src/main/res/layout/cardview_malfunction.xml
@@ -79,7 +79,8 @@
                     android:layout_height="wrap_content"
                     android:text="(at km)"
                     style="@style/textColor"
-                    android:textSize="12sp"/>
+                    android:textSize="12sp"
+                    tools:ignore="HardcodedText" />
 
 
             </LinearLayout>
@@ -91,7 +92,7 @@
                 android:gravity="center"
                 android:orientation="horizontal"
                 android:layout_weight="0">
-                
+
                 <com.google.android.material.floatingactionbutton.FloatingActionButton
                     android:id="@+id/card_malfunction_button_delete"
                     android:layout_width="wrap_content"

--- a/app/src/main/res/layout/cardview_malfunction.xml
+++ b/app/src/main/res/layout/cardview_malfunction.xml
@@ -90,6 +90,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:gravity="center"
+                android:layout_marginEnd="10dp"
                 android:orientation="horizontal"
                 android:layout_weight="0">
 

--- a/app/src/main/res/layout/cardview_malfunction.xml
+++ b/app/src/main/res/layout/cardview_malfunction.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto">
@@ -15,6 +16,7 @@
         app:cardCornerRadius="10dp"
         app:cardElevation="5dp">
 
+        <!-- TEXTS -->
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -47,7 +49,8 @@
                     android:text="(title)"
                     style="@style/textColor"
                     android:textSize="20sp"
-                    android:textStyle="bold"/>
+                    android:textStyle="bold"
+                    tools:ignore="HardcodedText" />
 
                 <!-- DATE -->
                 <TextView
@@ -56,7 +59,8 @@
                     android:layout_height="wrap_content"
                     android:text="(date)"
                     style="@style/textColor"
-                    android:textSize="16sp"/>
+                    android:textSize="16sp"
+                    tools:ignore="HardcodedText" />
 
                 <!-- STATUS -->
                 <TextView
@@ -65,7 +69,8 @@
                     android:layout_height="wrap_content"
                     android:text="(ongoing/fixed)"
                     style="@style/textColorSpecial"
-                    android:textSize="12sp"/>
+                    android:textSize="12sp"
+                    tools:ignore="HardcodedText" />
 
                 <!-- WHEN -->
                 <TextView
@@ -79,14 +84,14 @@
 
             </LinearLayout>
 
+            <!-- BUTTONS -->
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:gravity="center"
                 android:orientation="horizontal"
-                android:layout_weight="2">
-
-                <!-- BUTTONS -->
+                android:layout_weight="0">
+                
                 <com.google.android.material.floatingactionbutton.FloatingActionButton
                     android:id="@+id/card_malfunction_button_delete"
                     android:layout_width="wrap_content"

--- a/app/src/main/res/layout/cardview_malfunction.xml
+++ b/app/src/main/res/layout/cardview_malfunction.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
-        android:layout_height="105dp"
+        android:layout_height="match_parent"
         android:layout_marginTop="5dp"
         android:layout_marginBottom="10dp"
         android:layout_marginStart="5dp"
@@ -15,103 +15,101 @@
         app:cardCornerRadius="10dp"
         app:cardElevation="5dp">
 
-        <RelativeLayout
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:baselineAligned="false"
+            android:orientation="horizontal">
 
-            <!-- ID -->
-            <TextView
-                android:id="@+id/card_malfunction_hidden_id"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="60sp"
-                android:text="id"
-                style="@style/textColorSpecial"
-                android:textSize="12sp"
-                android:visibility="gone" />
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="10dp"
+                android:layout_marginBottom="10dp"
+                android:layout_weight="1"
+                android:orientation="vertical">
 
-            <!-- TITLE -->
-            <TextView
-                android:id="@+id/card_malfunction_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentStart="true"
-                android:layout_marginStart="7dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginEnd="7dp"
-                android:layout_marginBottom="8dp"
-                android:ellipsize="end"
-                android:lines="1"
-                android:scrollHorizontally="true"
-                android:text="(title)"
-                style="@style/textColor"
-                android:textSize="20sp"
-                android:textStyle="bold"/>
+                <!-- ID -->
+                <TextView
+                    android:id="@+id/card_malfunction_hidden_id"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text=""
+                    style="@style/textColorSpecial"
+                    android:visibility="gone" />
 
-            <!-- DATE -->
-            <TextView
-                android:id="@+id/card_malfunction_date"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="36sp"
-                android:text="(date)"
-                style="@style/textColor"
-                android:textSize="16sp"/>
+                <!-- TITLE -->
+                <TextView
+                    android:id="@+id/card_malfunction_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(title)"
+                    style="@style/textColor"
+                    android:textSize="20sp"
+                    android:textStyle="bold"/>
 
-            <!-- STATUS -->
-            <TextView
-                android:id="@+id/card_malfunction_status"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="60sp"
-                android:text="(ongoing/fixed)"
-                style="@style/textColorSpecial"
-                android:textSize="12sp"/>
+                <!-- DATE -->
+                <TextView
+                    android:id="@+id/card_malfunction_date"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(date)"
+                    style="@style/textColor"
+                    android:textSize="16sp"/>
 
-            <!-- WHEN -->
-            <TextView
-                android:id="@+id/card_malfunction_at_km"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="80sp"
-                android:text="(at km)"
-                style="@style/textColor"
-                android:textSize="12sp"/>
+                <!-- STATUS -->
+                <TextView
+                    android:id="@+id/card_malfunction_status"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(ongoing/fixed)"
+                    style="@style/textColorSpecial"
+                    android:textSize="12sp"/>
 
-            <!-- BUTTONS -->
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/card_malfunction_button_delete"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentBottom="true"
-                android:layout_marginEnd="65dp"
-                android:layout_marginBottom="21dp"
-                android:clickable="true"
-                android:scaleX="0.8"
-                android:scaleY="0.8"
-                app:backgroundTint="#FF0000"
-                app:srcCompat="@android:drawable/ic_menu_delete" />
+                <!-- WHEN -->
+                <TextView
+                    android:id="@+id/card_malfunction_at_km"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(at km)"
+                    style="@style/textColor"
+                    android:textSize="12sp"/>
 
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/card_malfunction_button_edit"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentBottom="true"
-                android:layout_marginEnd="9dp"
-                android:layout_marginBottom="21dp"
-                android:clickable="true"
-                android:scaleX="0.8"
-                android:scaleY="0.8"
-                app:backgroundTint="#3B89FF"
-                app:srcCompat="@android:drawable/ic_menu_edit" />
 
-        </RelativeLayout>
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:orientation="horizontal"
+                android:layout_weight="2">
+
+                <!-- BUTTONS -->
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/card_malfunction_button_delete"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:scaleX="0.8"
+                    android:scaleY="0.8"
+                    app:backgroundTint="#FF0000"
+                    app:srcCompat="@android:drawable/ic_menu_delete" />
+
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/card_malfunction_button_edit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:scaleX="0.8"
+                    android:scaleY="0.8"
+                    app:backgroundTint="#3B89FF"
+                    app:srcCompat="@android:drawable/ic_menu_edit" />
+
+            </LinearLayout>
+
+        </LinearLayout>
 
     </androidx.cardview.widget.CardView>
 

--- a/app/src/main/res/layout/cardview_repeated_trip.xml
+++ b/app/src/main/res/layout/cardview_repeated_trip.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
-        android:layout_height="130dp"
+        android:layout_height="match_parent"
         android:layout_marginStart="5dp"
         android:layout_marginTop="5dp"
         android:layout_marginEnd="5dp"
@@ -15,126 +16,130 @@
         app:cardCornerRadius="10dp"
         app:cardElevation="5dp">
 
-        <RelativeLayout
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:baselineAligned="false"
+            android:orientation="horizontal">
 
-            <!-- ID -->
-            <TextView
-                android:id="@+id/card_repeated_trip_hidden_id"
+            <!-- TITLES -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="10dp"
+                android:layout_weight="1"
+                android:layout_marginBottom="10dp"
+                android:orientation="vertical">
+
+                <!-- ID -->
+                <TextView
+                    android:id="@+id/card_repeated_trip_hidden_id"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="id"
+                    style="@style/textColor"
+                    android:textSize="12sp"
+                    android:visibility="gone"
+                    tools:ignore="HardcodedText" />
+
+                <!-- TITLE -->
+                <TextView
+                    android:id="@+id/card_repeated_trip_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(Title)"
+                    style="@style/textColor"
+                    android:textSize="20sp"
+                    android:textStyle="bold"
+                    tools:ignore="HardcodedText" />
+
+                <!-- TIMES PER WEEK -->
+                <TextView
+                    android:id="@+id/card_repeated_trip_times"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(x times per week)"
+                    style="@style/textColorSpecial"
+                    android:textSize="12sp"
+                    tools:ignore="HardcodedText" />
+
+                <!-- COST PER WEEK -->
+                <TextView
+                    android:id="@+id/card_repeated_trip_cost"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(Cost in eur per week)"
+                    style="@style/textColor"
+                    android:textSize="16sp"
+                    tools:ignore="HardcodedText" />
+
+                <!-- TOTAL LT -->
+                <TextView
+                    android:id="@+id/card_repeated_trip_lt"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(Lt consumed per week)"
+                    style="@style/textColor"
+                    android:textSize="12sp"
+                    tools:ignore="HardcodedText" />
+
+                <!-- TOTAL KM PER WEEK -->
+                <TextView
+                    android:id="@+id/card_repeated_trip_km"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(Trip's km|Total km per week)"
+                    style="@style/textColor"
+                    android:textSize="12sp"
+                    tools:ignore="HardcodedText" />
+
+                <!-- DATE ADDED -->
+                <TextView
+                    android:id="@+id/card_repeated_trip_date"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(Added on: date)"
+                    style="@style/textColorSpecial"
+                    android:textSize="12sp"
+                    tools:ignore="HardcodedText" />
+
+            </LinearLayout>
+
+            <!-- BUTTONS -->
+            <LinearLayout
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="60sp"
-                android:text="id"
-                style="@style/textColor"
-                android:textSize="12sp"
-                android:visibility="gone" />
+                android:layout_height="match_parent"
+                android:layout_weight="0"
+                android:layout_marginEnd="10dp"
+                android:gravity="center"
+                android:orientation="horizontal">
 
-            <!-- TITLE -->
-            <TextView
-                android:id="@+id/card_repeated_trip_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentStart="true"
-                android:layout_marginStart="7dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginEnd="7dp"
-                android:layout_marginBottom="8dp"
-                android:ellipsize="end"
-                android:lines="1"
-                android:scrollHorizontally="true"
-                android:text="(Title)"
-                style="@style/textColor"
-                android:textSize="20sp"
-                android:textStyle="bold" />
+                <!-- DELETE BUTTON -->
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/card_repeated_button_delete"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:scaleX="0.8"
+                    android:scaleY="0.8"
+                    app:backgroundTint="#FF0000"
+                    app:srcCompat="@android:drawable/ic_menu_delete" />
 
-            <!-- TIMES PER WEEK -->
-            <TextView
-                android:id="@+id/card_repeated_trip_times"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="36sp"
-                android:text="(x times per week)"
-                style="@style/textColorSpecial"
-                android:textSize="12sp" />
+                <!-- EDIT BUTTON -->
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/card_repeated_button_edit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:scaleX="0.8"
+                    android:scaleY="0.8"
+                    app:backgroundTint="#3B89FF"
+                    app:srcCompat="@android:drawable/ic_menu_edit" />
 
-            <!-- COST PER WEEK -->
-            <TextView
-                android:id="@+id/card_repeated_trip_cost"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="52sp"
-                android:text="(Cost in eur per week)"
-                style="@style/textColor"
-                android:textSize="16sp" />
+            </LinearLayout>
 
-            <!-- TOTAL LT -->
-            <TextView
-                android:id="@+id/card_repeated_trip_lt"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="75sp"
-                android:text="(Lt consumed per week)"
-                style="@style/textColor"
-                android:textSize="12sp" />
-
-            <!-- TOTAL KM PER WEEK -->
-            <TextView
-                android:id="@+id/card_repeated_trip_km"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="92sp"
-                android:text="(Trip's km|Total km per week)"
-                style="@style/textColor"
-                android:textSize="12sp" />
-
-            <!-- DATE ADDED -->
-            <TextView
-                android:id="@+id/card_repeated_trip_date"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="110sp"
-                android:text="(Added on: date)"
-                style="@style/textColorSpecial"
-                android:textSize="12sp" />
-
-            <!-- DELETE BUTTON -->
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/card_repeated_button_delete"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentBottom="true"
-                android:layout_marginEnd="65dp"
-                android:layout_marginBottom="35dp"
-                android:clickable="true"
-                android:scaleX="0.8"
-                android:scaleY="0.8"
-                app:backgroundTint="#FF0000"
-                app:srcCompat="@android:drawable/ic_menu_delete" />
-
-            <!-- EDIT BUTTON -->
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/card_repeated_button_edit"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentBottom="true"
-                android:layout_marginEnd="9dp"
-                android:layout_marginBottom="35dp"
-                android:clickable="true"
-                android:scaleX="0.8"
-                android:scaleY="0.8"
-                app:backgroundTint="#3B89FF"
-                app:srcCompat="@android:drawable/ic_menu_edit" />
-
-        </RelativeLayout>
+        </LinearLayout>
 
     </androidx.cardview.widget.CardView>
 

--- a/app/src/main/res/layout/cardview_service.xml
+++ b/app/src/main/res/layout/cardview_service.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
-        android:layout_height="105dp"
+        android:layout_height="match_parent"
         android:layout_marginTop="5dp"
         android:layout_marginBottom="10dp"
         android:layout_marginStart="5dp"
@@ -15,99 +16,103 @@
         app:cardCornerRadius="10dp"
         app:cardElevation="5dp">
 
-        <RelativeLayout
+        <!-- CONTAINER -->
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:baselineAligned="false"
+            android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/card_service_at_km"
+            <!-- LABELS -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="10dp"
+                android:layout_weight="1"
+                android:layout_marginBottom="10dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/card_service_hidden_id"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="id"
+                    style="@style/textColorSpecial"
+                    android:textSize="12sp"
+                    android:visibility="gone"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/card_service_at_km"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(at km)"
+                    style="@style/textColor"
+                    android:textSize="20sp"
+                    android:textStyle="bold"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/card_service_cost"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(cost)"
+                    style="@style/textColor"
+                    android:textSize="16sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/card_service_date"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(date)"
+                    style="@style/textColorSpecial"
+                    android:textSize="12sp"
+                    tools:ignore="HardcodedText" />
+
+                <TextView
+                    android:id="@+id/card_service_next_km"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(next at km)"
+                    style="@style/textColorSpecial"
+                    android:textSize="12sp"
+                    tools:ignore="HardcodedText" />
+
+            </LinearLayout>
+
+            <!-- BUTTONS -->
+            <LinearLayout
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentStart="true"
-                android:layout_marginStart="7dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginEnd="7dp"
-                android:layout_marginBottom="8dp"
-                android:ellipsize="end"
-                android:lines="1"
-                android:scrollHorizontally="true"
-                android:text="(at km)"
-                style="@style/textColor"
-                android:textSize="20sp"
-                android:textStyle="bold"/>
+                android:layout_height="match_parent"
+                android:layout_weight="0"
+                android:layout_marginEnd="10dp"
+                android:gravity="center"
+                android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/card_service_cost"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="36sp"
-                android:text="(cost)"
-                style="@style/textColor"
-                android:textSize="16sp"/>
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/card_service_button_delete"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:scaleX="0.8"
+                    android:scaleY="0.8"
+                    app:backgroundTint="#FF0000"
+                    app:srcCompat="@android:drawable/ic_menu_delete" />
+
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/card_service_button_edit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:scaleX="0.8"
+                    android:scaleY="0.8"
+                    app:backgroundTint="#3B89FF"
+                    app:srcCompat="@android:drawable/ic_menu_edit" />
 
 
-            <TextView
-                android:id="@+id/card_service_date"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="60sp"
-                android:text="(date)"
-                style="@style/textColorSpecial"
-                android:textSize="12sp"/>
-
-            <TextView
-                android:id="@+id/card_service_hidden_id"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="60sp"
-                android:text="id"
-                style="@style/textColorSpecial"
-                android:textSize="12sp"
-                android:visibility="gone" />
-
-            <TextView
-                android:id="@+id/card_service_next_km"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="80sp"
-                android:text="(next at km)"
-                style="@style/textColorSpecial"
-                android:textSize="12sp"/>
-
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/card_service_button_delete"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentBottom="true"
-                android:layout_marginEnd="65dp"
-                android:layout_marginBottom="21dp"
-                android:clickable="true"
-                android:scaleX="0.8"
-                android:scaleY="0.8"
-                app:backgroundTint="#FF0000"
-                app:srcCompat="@android:drawable/ic_menu_delete" />
-
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/card_service_button_edit"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentBottom="true"
-                android:layout_marginEnd="9dp"
-                android:layout_marginBottom="21dp"
-                android:clickable="true"
-                android:scaleX="0.8"
-                android:scaleY="0.8"
-                app:backgroundTint="#3B89FF"
-                app:srcCompat="@android:drawable/ic_menu_edit" />
-
-        </RelativeLayout>
-
+            </LinearLayout>
+        </LinearLayout>
     </androidx.cardview.widget.CardView>
-
 </LinearLayout>

--- a/app/src/main/res/layout/cardview_trip.xml
+++ b/app/src/main/res/layout/cardview_trip.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
-        android:layout_height="125dp"
+        android:layout_height="match_parent"
         android:layout_marginStart="5dp"
         android:layout_marginTop="5dp"
         android:layout_marginEnd="5dp"
@@ -15,116 +16,121 @@
         app:cardCornerRadius="10dp"
         app:cardElevation="5dp">
 
-        <RelativeLayout
+        <!-- CONTAINER -->
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:baselineAligned="false"
+            android:orientation="horizontal">
 
-            <!-- ID -->
-            <TextView
-                android:id="@+id/card_trip_hidden_id"
+            <!-- TITLES -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginStart="10dp"
+                android:layout_marginTop="10dp"
+                android:layout_weight="1"
+                android:layout_marginBottom="10dp"
+                android:orientation="vertical">
+
+                <!-- ID -->
+                <TextView
+                    android:id="@+id/card_trip_hidden_id"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="id"
+                    style="@style/textColor"
+                    android:textSize="12sp"
+                    android:visibility="gone"
+                    tools:ignore="HardcodedText" />
+
+                <!-- TITLE -->
+                <TextView
+                    android:id="@+id/card_trip_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:scrollHorizontally="true"
+                    android:text="(Title)"
+                    style="@style/textColor"
+                    android:textSize="20sp"
+                    android:textStyle="bold"
+                    tools:ignore="HardcodedText" />
+
+                <!-- ONE TIME TRIP -->
+                <TextView
+                    android:id="@+id/card_trip_one_time"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(one time trip)"
+                    style="@style/textColorSpecial"
+                    android:textSize="12sp"
+                    tools:ignore="HardcodedText" />
+
+                <!-- COST -->
+                <TextView
+                    android:id="@+id/card_trip_cost"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(Cost in eur)"
+                    style="@style/textColor"
+                    android:textSize="16sp"
+                    tools:ignore="HardcodedText" />
+
+                <!-- TOTAL KM -->
+                <TextView
+                    android:id="@+id/card_trip_km"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(Total km)"
+                    style="@style/textColor"
+                    android:textSize="16sp"
+                    tools:ignore="HardcodedText" />
+
+                <!-- DATE CREATED -->
+                <TextView
+                    android:id="@+id/card_trip_date_added"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="(Added date)"
+                    style="@style/textColorSpecial"
+                    android:textSize="12sp"
+                    tools:ignore="HardcodedText" />
+
+            </LinearLayout>
+
+            <!-- BUTTONS -->
+            <LinearLayout
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="60sp"
-                android:text="id"
-                style="@style/textColor"
-                android:textSize="12sp"
-                android:visibility="gone" />
+                android:layout_height="match_parent"
+                android:layout_weight="0"
+                android:layout_marginEnd="10dp"
+                android:gravity="center"
+                android:orientation="horizontal">
 
-            <!-- TITLE -->
-            <TextView
-                android:id="@+id/card_trip_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentStart="true"
-                android:layout_marginStart="7dp"
-                android:layout_marginTop="8dp"
-                android:layout_marginEnd="7dp"
-                android:layout_marginBottom="8dp"
-                android:ellipsize="end"
-                android:lines="1"
-                android:scrollHorizontally="true"
-                android:text="(Title)"
-                style="@style/textColor"
-                android:textSize="20sp"
-                android:textStyle="bold" />
+                <!-- DELETE BUTTON -->
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/card_trip_button_delete"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:scaleX="0.8"
+                    android:scaleY="0.8"
+                    app:backgroundTint="@color/red"
+                    app:srcCompat="@android:drawable/ic_menu_delete" />
 
-            <!-- ONE TIME TRIP -->
-            <TextView
-                android:id="@+id/card_trip_one_time"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="36sp"
-                android:text="(one time trip)"
-                style="@style/textColorSpecial"
-                android:textSize="12sp" />
+                <!-- EDIT BUTTON -->
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
+                    android:id="@+id/card_trip_button_edit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    android:scaleX="0.8"
+                    android:scaleY="0.8"
+                    app:backgroundTint="#3B89FF"
+                    app:srcCompat="@android:drawable/ic_menu_edit" />
 
-            <!-- COST -->
-            <TextView
-                android:id="@+id/card_trip_cost"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="52sp"
-                android:text="(Cost in eur)"
-                style="@style/textColor"
-                android:textSize="16sp" />
 
-            <!-- TOTAL KM -->
-            <TextView
-                android:id="@+id/card_trip_km"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="75sp"
-                android:text="(Total km)"
-                style="@style/textColor"
-                android:textSize="16sp" />
-
-            <!-- DATE CREATED -->
-            <TextView
-                android:id="@+id/card_trip_date_added"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="100sp"
-                android:text="(Added date)"
-                style="@style/textColorSpecial"
-                android:textSize="12sp" />
-
-            <!-- DELETE BUTTON -->
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/card_trip_button_delete"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentBottom="true"
-                android:layout_marginEnd="65dp"
-                android:layout_marginBottom="32dp"
-                android:clickable="true"
-                android:scaleX="0.8"
-                android:scaleY="0.8"
-                app:backgroundTint="@color/red"
-                app:srcCompat="@android:drawable/ic_menu_delete" />
-
-            <!-- EDIT BUTTON -->
-            <com.google.android.material.floatingactionbutton.FloatingActionButton
-                android:id="@+id/card_trip_button_edit"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_alignParentBottom="true"
-                android:layout_marginEnd="9dp"
-                android:layout_marginBottom="32dp"
-                android:clickable="true"
-                android:scaleX="0.8"
-                android:scaleY="0.8"
-                app:backgroundTint="#3B89FF"
-                app:srcCompat="@android:drawable/ic_menu_edit" />
-
-        </RelativeLayout>
-
+            </LinearLayout>
+        </LinearLayout>
     </androidx.cardview.widget.CardView>
-
 </LinearLayout>


### PR DESCRIPTION
## Overview
The old method involved having a Relative Layout with all the views squashed in them. Now there's a linear layout that holds two linear layouts inside of it. The first one contains the text views and has a layout weight of 1, and the other one holds the buttons and has a layout weight of 0, while remaining wrapped around its content.

![image](https://github.com/user-attachments/assets/8f6b6297-2167-4166-b69e-38e8cfe78dbd)

This will ensure that almost all displays no matter their size, will display correctly the buttons and the strings.