### PR TITLE
Hotfix -- Version 1.1.1: Fixed form fields across several occurrences.

### DIFF
--- a/lib/views/car/claim_old_car.dart
+++ b/lib/views/car/claim_old_car.dart
@@ -1,6 +1,7 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:benzinapp/services/managers/car_manager.dart';
 import 'package:benzinapp/views/car/dashboard.dart';
+import 'package:benzinapp/views/shared/password_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_translate/flutter_translate.dart';
 
@@ -117,24 +118,17 @@ class _ClaimOldCarState extends State<ClaimOldCar> {
                     const SizedBox(height: 20),
 
                     // Password TextField
-                    TextField(
+                    PasswordField(
                       enabled: !isSearching,
                       controller: passwordController,
+                      errorText: passwordError,
+                      hintText: translate('passwordHint'),
+                      labelText: translate('password'),
                       onChanged: (value) {
                         setState(() {
                           passwordEmpty = value.isEmpty;
                         });
                       },
-                      obscureText: true,
-                      decoration: InputDecoration(
-                        errorText: passwordError,
-                        hintText: translate('passwordHint'),
-                        labelText: translate('password'),
-                        prefixIcon: const Icon(Icons.lock),
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(30.0),
-                        ),
-                      ),
                     ),
 
                     const SizedBox(height: 60),

--- a/lib/views/confirmations/reset_password_second_step.dart
+++ b/lib/views/confirmations/reset_password_second_step.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:benzinapp/services/managers/user_manager.dart';
 import 'package:benzinapp/views/login.dart';
 import 'package:benzinapp/views/shared/notification.dart';
+import 'package:benzinapp/views/shared/password_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_translate/flutter_translate.dart';
 import 'package:pin_code_fields/pin_code_fields.dart';
@@ -335,40 +336,26 @@ class _ResetPasswordFirstStep extends State<ResetPasswordSecondStep> {
 
                 const SizedBox(height: 20),
 
-                TextField(
+                PasswordField(
                   enabled: !isLoading,
                   controller: newPasswordController,
-                  keyboardType: TextInputType.text,
-                  obscureText: true,
+                  errorText: passwordError,
+                  hintText: translate('forgotPasswordSecondStepPasswordHint'),
+                  labelText: translate('forgotPasswordSecondStepPasswordLabel'),
+                  prefixIcon: const Icon(Icons.enhanced_encryption),
                   textInputAction: TextInputAction.next,
-                  decoration: InputDecoration(
-                    errorText: passwordError,
-                    hintText: translate('forgotPasswordSecondStepPasswordHint'),
-                    labelText: translate('forgotPasswordSecondStepPasswordLabel'),
-                    prefixIcon: const Icon(Icons.enhanced_encryption),
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(30.0),
-                    ),
-                  ),
                 ),
 
                 const SizedBox(height: 25),
 
-                TextField(
+                PasswordField(
                   enabled: !isLoading,
                   controller: newPasswordConfirmController,
-                  keyboardType: TextInputType.text,
-                  obscureText: true,
+                  errorText: passwordConfirmError,
+                  hintText: translate('forgotPasswordSecondStepPasswordConfirmHint'),
+                  labelText: translate('forgotPasswordSecondStepPasswordConfirmLabel'),
+                  prefixIcon: const Icon(Icons.enhanced_encryption_outlined),
                   textInputAction: TextInputAction.done,
-                  decoration: InputDecoration(
-                    errorText: passwordConfirmError,
-                    hintText: translate('forgotPasswordSecondStepPasswordConfirmHint'),
-                    labelText: translate('forgotPasswordSecondStepPasswordConfirmLabel'),
-                    prefixIcon: const Icon(Icons.enhanced_encryption_outlined),
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(30.0),
-                    ),
-                  ),
                 ),
               ],
             ),

--- a/lib/views/login.dart
+++ b/lib/views/login.dart
@@ -25,6 +25,7 @@ class _LoginPageState extends State<LoginPage> {
 
   final TextEditingController emailController = TextEditingController();
   final TextEditingController passwordController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
 
   String? emailError;
   String? passwordError;
@@ -216,78 +217,87 @@ class _LoginPageState extends State<LoginPage> {
               const SizedBox(height: 60),
 
               // E-mail text field
-              TextField(
-                enabled: !isLoggingIn,
-                controller: emailController,
-                keyboardType: TextInputType.emailAddress,
-                textInputAction: TextInputAction.next,
-                onChanged: (value) {
-                  setState(() {
-                    showUnlockButton = false;
-                  });
-                },
-                decoration: InputDecoration(
-                  errorText: emailError,
-                  hintText: translate('emailHint'),
-                  labelText: translate('email'),
-                  prefixIcon: const Icon(Icons.email),
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(30.0),
-                  ),
-                ),
-              ),
-
-              const SizedBox(height: 16.0),
-
-              // Password TextField
-              TextField(
-                enabled: !isLoggingIn,
-                controller: passwordController,
-                obscureText: !_passwordVisible,
-                decoration: InputDecoration(
-                  errorText: passwordError,
-                  hintText: translate('passwordHint'),
-                  labelText: translate('password'),
-                  prefixIcon: const Icon(Icons.lock),
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(30.0),
-                  ),
-                  suffixIcon: IconButton(
-                    icon: Icon(
-                      _passwordVisible
-                          ? Icons.visibility
-                          : Icons.visibility_off,
+              Form(
+                key: _formKey,
+                child: Column(
+                  children: [
+                    TextFormField(
+                      enabled: !isLoggingIn,
+                      controller: emailController,
+                      keyboardType: TextInputType.emailAddress,
+                      maxLength: 256,
+                      textInputAction: TextInputAction.next,
+                      onChanged: (value) {
+                        setState(() {
+                          showUnlockButton = false;
+                        });
+                      },
+                      decoration: InputDecoration(
+                        errorText: emailError,
+                        hintText: translate('emailHint'),
+                        labelText: translate('email'),
+                        counterText: '',
+                        prefixIcon: const Icon(Icons.email),
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(30.0),
+                        ),
+                      ),
                     ),
-                    onPressed: () {
-                      setState(() {
-                        _passwordVisible = !_passwordVisible;
-                      });
-                    },
-                  ),
-                ),
-              ),
 
-              const SizedBox(height: 25),
+                    const SizedBox(height: 16.0),
 
-              if (showUnlockButton)
-              Center(
-                child: FilledButton.tonalIcon(
-                  icon: const Icon(Icons.lock_reset),
-                  label: Text(translate('unlockAccountButton')),
-                  style: FilledButton.styleFrom(
-                    backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
-                    textStyle: const TextStyle(
-                      fontSize: 16,
+                    // Password TextField
+                    TextFormField(
+                      enabled: !isLoggingIn,
+                      controller: passwordController,
+                      obscureText: !_passwordVisible,
+                      decoration: InputDecoration(
+                        errorText: passwordError,
+                        hintText: translate('passwordHint'),
+                        labelText: translate('password'),
+                        prefixIcon: const Icon(Icons.lock),
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(30.0),
+                        ),
+                        suffixIcon: IconButton(
+                          icon: Icon(
+                            _passwordVisible
+                                ? Icons.visibility
+                                : Icons.visibility_off,
+                          ),
+                          onPressed: () {
+                            setState(() {
+                              _passwordVisible = !_passwordVisible;
+                            });
+                          },
+                        ),
+                      ),
                     ),
-                  ),
-                  onPressed: () {
-                    Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => UnlockAccountScreen(email: emailController.text)
-                        )
-                    );
-                  },
+
+                    const SizedBox(height: 25),
+
+                    if (showUnlockButton)
+                      Center(
+                        child: FilledButton.tonalIcon(
+                          icon: const Icon(Icons.lock_reset),
+                          label: Text(translate('unlockAccountButton')),
+                          style: FilledButton.styleFrom(
+                            backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
+                            textStyle: const TextStyle(
+                              fontSize: 16,
+                            ),
+                          ),
+                          onPressed: () {
+                            Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                    builder: (context) => UnlockAccountScreen(email: emailController.text)
+                                )
+                            );
+                          },
+                        ),
+                      ),
+                  ],
                 ),
               ),
 

--- a/lib/views/login.dart
+++ b/lib/views/login.dart
@@ -9,6 +9,7 @@ import 'package:benzinapp/views/confirmations/unlock_account.dart';
 import 'package:benzinapp/views/fragments/settings.dart';
 import 'package:benzinapp/views/register.dart';
 import 'package:benzinapp/views/shared/notification.dart';
+import 'package:benzinapp/views/shared/password_field.dart';
 import 'package:flutter_translate/flutter_translate.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -33,7 +34,7 @@ class _LoginPageState extends State<LoginPage> {
 
   bool isLoggingIn = false;
   bool showUnlockButton = false;
-  bool _passwordVisible = false;
+
 
   void sendLoginPayload() async {
 
@@ -251,33 +252,14 @@ class _LoginPageState extends State<LoginPage> {
                       const SizedBox(height: 16.0),
                 
                       // Password TextField
-                      TextFormField(
+                      PasswordField(
                         enabled: !isLoggingIn,
                         controller: passwordController,
-                        obscureText: !_passwordVisible,
-                        autofillHints: const [AutofillHints.password],
-                        decoration: InputDecoration(
-                          errorText: passwordError,
-                          hintText: translate('passwordHint'),
-                          labelText: translate('password'),
-                          prefixIcon: const Icon(Icons.lock),
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(30.0),
-                          ),
-                          suffixIcon: IconButton(
-                            icon: Icon(
-                              _passwordVisible
-                                  ? Icons.visibility
-                                  : Icons.visibility_off,
-                            ),
-                            onPressed: () {
-                              setState(() {
-                                _passwordVisible = !_passwordVisible;
-                              });
-                            },
-                          ),
-                        ),
+                        errorText: passwordError,
+                        hintText: translate('passwordHint'),
+                        labelText: translate('password'),
                       ),
+
                 
                       const SizedBox(height: 25),
 

--- a/lib/views/login.dart
+++ b/lib/views/login.dart
@@ -11,6 +11,7 @@ import 'package:benzinapp/views/register.dart';
 import 'package:benzinapp/views/shared/notification.dart';
 import 'package:flutter_translate/flutter_translate.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key, this.message});
@@ -58,6 +59,7 @@ class _LoginPageState extends State<LoginPage> {
 
     switch (result) {
       case SessionStatus.success:
+        TextInput.finishAutofillContext();
         // show the message that the user is authorized successfully.
         SnackbarNotification.show(MessageType.success, translate('successfullyLoggedIn'));
         DataHolder().initializeValues();
@@ -219,85 +221,89 @@ class _LoginPageState extends State<LoginPage> {
               // E-mail text field
               Form(
                 key: _formKey,
-                child: Column(
-                  children: [
-                    TextFormField(
-                      enabled: !isLoggingIn,
-                      controller: emailController,
-                      keyboardType: TextInputType.emailAddress,
-                      maxLength: 256,
-                      textInputAction: TextInputAction.next,
-                      onChanged: (value) {
-                        setState(() {
-                          showUnlockButton = false;
-                        });
-                      },
-                      decoration: InputDecoration(
-                        errorText: emailError,
-                        hintText: translate('emailHint'),
-                        labelText: translate('email'),
-                        counterText: '',
-                        prefixIcon: const Icon(Icons.email),
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(30.0),
-                        ),
-                      ),
-                    ),
-
-                    const SizedBox(height: 16.0),
-
-                    // Password TextField
-                    TextFormField(
-                      enabled: !isLoggingIn,
-                      controller: passwordController,
-                      obscureText: !_passwordVisible,
-                      decoration: InputDecoration(
-                        errorText: passwordError,
-                        hintText: translate('passwordHint'),
-                        labelText: translate('password'),
-                        prefixIcon: const Icon(Icons.lock),
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(30.0),
-                        ),
-                        suffixIcon: IconButton(
-                          icon: Icon(
-                            _passwordVisible
-                                ? Icons.visibility
-                                : Icons.visibility_off,
+                child: AutofillGroup(
+                  child: Column(
+                    children: [
+                      TextFormField(
+                        enabled: !isLoggingIn,
+                        controller: emailController,
+                        keyboardType: TextInputType.emailAddress,
+                        autofillHints: const [AutofillHints.email],
+                        maxLength: 256,
+                        textInputAction: TextInputAction.next,
+                        onChanged: (value) {
+                          setState(() {
+                            showUnlockButton = false;
+                          });
+                        },
+                        decoration: InputDecoration(
+                          errorText: emailError,
+                          hintText: translate('emailHint'),
+                          labelText: translate('email'),
+                          counterText: '',
+                          prefixIcon: const Icon(Icons.email),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(30.0),
                           ),
-                          onPressed: () {
-                            setState(() {
-                              _passwordVisible = !_passwordVisible;
-                            });
-                          },
                         ),
                       ),
-                    ),
-
-                    const SizedBox(height: 25),
-
-                    if (showUnlockButton)
-                      Center(
-                        child: FilledButton.tonalIcon(
-                          icon: const Icon(Icons.lock_reset),
-                          label: Text(translate('unlockAccountButton')),
-                          style: FilledButton.styleFrom(
-                            backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
-                            textStyle: const TextStyle(
-                              fontSize: 16,
+                
+                      const SizedBox(height: 16.0),
+                
+                      // Password TextField
+                      TextFormField(
+                        enabled: !isLoggingIn,
+                        controller: passwordController,
+                        obscureText: !_passwordVisible,
+                        autofillHints: const [AutofillHints.password],
+                        decoration: InputDecoration(
+                          errorText: passwordError,
+                          hintText: translate('passwordHint'),
+                          labelText: translate('password'),
+                          prefixIcon: const Icon(Icons.lock),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(30.0),
+                          ),
+                          suffixIcon: IconButton(
+                            icon: Icon(
+                              _passwordVisible
+                                  ? Icons.visibility
+                                  : Icons.visibility_off,
                             ),
+                            onPressed: () {
+                              setState(() {
+                                _passwordVisible = !_passwordVisible;
+                              });
+                            },
                           ),
-                          onPressed: () {
-                            Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) => UnlockAccountScreen(email: emailController.text)
-                                )
-                            );
-                          },
                         ),
                       ),
-                  ],
+                
+                      const SizedBox(height: 25),
+
+                      if (showUnlockButton)
+                        Center(
+                          child: FilledButton.tonalIcon(
+                            icon: const Icon(Icons.lock_reset),
+                            label: Text(translate('unlockAccountButton')),
+                            style: FilledButton.styleFrom(
+                              backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
+                              textStyle: const TextStyle(
+                                fontSize: 16,
+                              ),
+                            ),
+                            onPressed: () {
+                              Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (context) => UnlockAccountScreen(email: emailController.text)
+                                  )
+                              );
+                            },
+                          ),
+                        ),
+                    ],
+                  ),
                 ),
               ),
 

--- a/lib/views/profile/delete_account_screen.dart
+++ b/lib/views/profile/delete_account_screen.dart
@@ -2,6 +2,7 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:benzinapp/services/managers/user_manager.dart';
 import 'package:benzinapp/views/login.dart';
 import 'package:benzinapp/views/shared/notification.dart';
+import 'package:benzinapp/views/shared/password_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_translate/flutter_translate.dart';
 
@@ -172,22 +173,15 @@ class _DeleteAccountScreenState extends State<DeleteAccountScreen> {
                 ),
               ),
               const SizedBox(height: 10),
-              TextField(
+              PasswordField(
                 enabled: !_isSending,
                 controller: _passwordController,
                 onChanged: (value) {
                   setState(() {});
                 },
-                keyboardType: TextInputType.text,
                 textInputAction: TextInputAction.done,
-                obscureText: true,
-                decoration: InputDecoration(
-                  labelText: translate('deleteAccountRetypePassword'),
-                  prefixIcon: const Icon(Icons.password),
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(30.0),
-                  ),
-                ),
+                labelText: translate('deleteAccountRetypePassword'),
+                prefixIcon: const Icon(Icons.password),
               ),
             ],
           ),

--- a/lib/views/register.dart
+++ b/lib/views/register.dart
@@ -193,110 +193,117 @@ class _RegisterPageState extends State<RegisterPage> {
               const SizedBox(height: 40),
               Form(
                 key: _formKey,
-                child: Column(
-                  children: [
-                    TextFormField(
-                      controller: emailController,
-                      keyboardType: TextInputType.text,
-                      maxLength: 256,
-                      textInputAction: TextInputAction.next,
-                      decoration: InputDecoration(
-                        errorText: emailError,
-                        hintText: translate('emailHint'),
-                        counterText: '',
-                        labelText: translate('email'),
-                        prefixIcon: const Icon(Icons.email),
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(30.0),
+                child: AutofillGroup(
+                  child: Column(
+                    children: [
+                      TextFormField(
+                        controller: emailController,
+                        keyboardType: TextInputType.emailAddress,
+                        autofillHints: const [AutofillHints.email],
+                        maxLength: 256,
+                        textInputAction: TextInputAction.next,
+                        decoration: InputDecoration(
+                          errorText: emailError,
+                          hintText: translate('emailHint'),
+                          counterText: '',
+                          labelText: translate('email'),
+                          prefixIcon: const Icon(Icons.email),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(30.0),
+                          ),
                         ),
                       ),
-                    ),
-                    const SizedBox(height: 10),
-                    TextFormField(
-                      controller: usernameController,
-                      keyboardType: TextInputType.text,
-                      maxLength: 16,
-                      textInputAction: TextInputAction.next,
-                      decoration: InputDecoration(
-                        errorText: usernameError,
-                        hintText: translate('usernameRegisterHint'),
-                        errorMaxLines: 4,
-                        labelText: translate('username'),
-                        prefixIcon: const Icon(Icons.person),
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(30.0),
+                      const SizedBox(height: 10),
+                      TextFormField(
+                        controller: usernameController,
+                        keyboardType: TextInputType.text,
+                        autofillHints: const [AutofillHints.newUsername],
+                        maxLength: 16,
+                        textInputAction: TextInputAction.next,
+                        decoration: InputDecoration(
+                          errorText: usernameError,
+                          hintText: translate('usernameRegisterHint'),
+                          errorMaxLines: 4,
+                          labelText: translate('username'),
+                          prefixIcon: const Icon(Icons.person),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(30.0),
+                          ),
                         ),
                       ),
-                    ),
-                    const SizedBox(height: 10),
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Expanded(
-                          child: TextFormField(
-                            controller: passwordController,
-                            textInputAction: TextInputAction.next,
-                            obscureText: !_passwordVisible,
-                            maxLength: 128,
-                            decoration: InputDecoration(
-                              errorText: passwordError,
-                              errorMaxLines: 4,
-                              counterText: '',
-                              hintText: translate('passwordHint'),
-                              labelText: translate('password'),
-                              prefixIcon: const Icon(Icons.lock),
-                              border: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(30.0),
-                              ),
-                              suffixIcon: IconButton(
-                                icon: Icon(
-                                  _passwordVisible
-                                      ? Icons.visibility
-                                      : Icons.visibility_off,
+                      const SizedBox(height: 10),
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Expanded(
+                            child: TextFormField(
+                              controller: passwordController,
+                              textInputAction: TextInputAction.next,
+                              obscureText: !_passwordVisible,
+                              autofillHints: const [AutofillHints.newPassword],
+                              maxLength: 128,
+                              decoration: InputDecoration(
+                                errorText: passwordError,
+                                errorMaxLines: 4,
+                                counterText: '',
+                                hintText: translate('passwordHint'),
+                                labelText: translate('password'),
+                                prefixIcon: const Icon(Icons.lock),
+                                border: OutlineInputBorder(
+                                  borderRadius: BorderRadius.circular(30.0),
                                 ),
-                                onPressed: () {
-                                  setState(() {
-                                    _passwordVisible = !_passwordVisible;
-                                  });
-                                },
+                                suffixIcon: IconButton(
+                                  icon: Icon(
+                                    _passwordVisible
+                                        ? Icons.visibility
+                                        : Icons.visibility_off,
+                                  ),
+                                  onPressed: () {
+                                    setState(() {
+                                      _passwordVisible = !_passwordVisible;
+                                    });
+                                  },
+                                ),
                               ),
                             ),
                           ),
-                        ),
-                        const SizedBox(width: 7.5),
-                        Expanded(
-                          child: TextFormField(
-                            controller: passwordConfirmController,
-                            textInputAction: TextInputAction.next,
-                            obscureText: !_confirmPasswordVisible,
-                            maxLength: 128,
-                            decoration: InputDecoration(
-                              errorText: passwordConfirmError,
-                              hintText: translate('passwordConfirmationHint'),
-                              labelText: translate('passwordConfirmation'),
-                              prefixIcon: const Icon(Icons.lock_outline),
-                              counterText: '',
-                              border: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(30.0),
-                              ),
-                              suffixIcon: IconButton(
-                                icon: Icon(
-                                  _confirmPasswordVisible
-                                      ? Icons.visibility
-                                      : Icons.visibility_off,
+                          const SizedBox(width: 7.5),
+                          Expanded(
+                            child: TextFormField(
+                              controller: passwordConfirmController,
+                              textInputAction: TextInputAction.done,
+                              onFieldSubmitted: (_) => _sendRegisterPayload(),
+                              obscureText: !_confirmPasswordVisible,
+                              autofillHints: const [AutofillHints.newPassword],
+                              maxLength: 128,
+                              decoration: InputDecoration(
+                                errorText: passwordConfirmError,
+                                hintText: translate('passwordConfirmationHint'),
+                                labelText: translate('passwordConfirmation'),
+                                prefixIcon: const Icon(Icons.lock_outline),
+                                counterText: '',
+                                border: OutlineInputBorder(
+                                  borderRadius: BorderRadius.circular(30.0),
                                 ),
-                                onPressed: () {
-                                  setState(() {
-                                    _confirmPasswordVisible = !_confirmPasswordVisible;
-                                  });
-                                },
+                                suffixIcon: IconButton(
+                                  icon: Icon(
+                                    _confirmPasswordVisible
+                                        ? Icons.visibility
+                                        : Icons.visibility_off,
+                                  ),
+                                  onPressed: () {
+                                    setState(() {
+                                      _confirmPasswordVisible = !_confirmPasswordVisible;
+                                    });
+                                  },
+                                ),
                               ),
                             ),
-                          ),
-                        )
-                      ],
-                    ),
-                  ],
+                          )
+                        ],
+                      ),
+                    ],
+                  ),
                 ),
               ),
               const SizedBox(height: 50),

--- a/lib/views/register.dart
+++ b/lib/views/register.dart
@@ -5,6 +5,7 @@ import 'package:benzinapp/views/about/privacy_policy.dart';
 import 'package:benzinapp/views/confirmations/confirm_email.dart';
 import 'package:benzinapp/views/fragments/settings.dart';
 import 'package:benzinapp/views/shared/notification.dart';
+import 'package:benzinapp/views/shared/password_field.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_translate/flutter_translate.dart';
@@ -25,9 +26,8 @@ class _RegisterPageState extends State<RegisterPage> {
 
   String? usernameError, passwordError, passwordConfirmError, emailError;
   bool isRegistering = false;
-  bool _passwordVisible = false;
-  bool _confirmPasswordVisible = false;
   bool _termsAccepted = false;
+
 
   final _formKey = GlobalKey<FormState>();
 
@@ -236,68 +236,29 @@ class _RegisterPageState extends State<RegisterPage> {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Expanded(
-                            child: TextFormField(
+                            child: PasswordField(
                               controller: passwordController,
                               textInputAction: TextInputAction.next,
-                              obscureText: !_passwordVisible,
                               autofillHints: const [AutofillHints.newPassword],
                               maxLength: 128,
-                              decoration: InputDecoration(
-                                errorText: passwordError,
-                                errorMaxLines: 4,
-                                counterText: '',
-                                hintText: translate('passwordHint'),
-                                labelText: translate('password'),
-                                prefixIcon: const Icon(Icons.lock),
-                                border: OutlineInputBorder(
-                                  borderRadius: BorderRadius.circular(30.0),
-                                ),
-                                suffixIcon: IconButton(
-                                  icon: Icon(
-                                    _passwordVisible
-                                        ? Icons.visibility
-                                        : Icons.visibility_off,
-                                  ),
-                                  onPressed: () {
-                                    setState(() {
-                                      _passwordVisible = !_passwordVisible;
-                                    });
-                                  },
-                                ),
-                              ),
+                              errorText: passwordError,
+                              errorMaxLines: 4,
+                              hintText: translate('passwordHint'),
+                              labelText: translate('password'),
                             ),
                           ),
                           const SizedBox(width: 7.5),
                           Expanded(
-                            child: TextFormField(
+                            child: PasswordField(
                               controller: passwordConfirmController,
                               textInputAction: TextInputAction.done,
                               onFieldSubmitted: (_) => _sendRegisterPayload(),
-                              obscureText: !_confirmPasswordVisible,
                               autofillHints: const [AutofillHints.newPassword],
                               maxLength: 128,
-                              decoration: InputDecoration(
-                                errorText: passwordConfirmError,
-                                hintText: translate('passwordConfirmationHint'),
-                                labelText: translate('passwordConfirmation'),
-                                prefixIcon: const Icon(Icons.lock_outline),
-                                counterText: '',
-                                border: OutlineInputBorder(
-                                  borderRadius: BorderRadius.circular(30.0),
-                                ),
-                                suffixIcon: IconButton(
-                                  icon: Icon(
-                                    _confirmPasswordVisible
-                                        ? Icons.visibility
-                                        : Icons.visibility_off,
-                                  ),
-                                  onPressed: () {
-                                    setState(() {
-                                      _confirmPasswordVisible = !_confirmPasswordVisible;
-                                    });
-                                  },
-                                ),
-                              ),
+                              errorText: passwordConfirmError,
+                              hintText: translate('passwordConfirmationHint'),
+                              labelText: translate('passwordConfirmation'),
+                              prefixIcon: const Icon(Icons.lock_outline),
                             ),
                           )
                         ],

--- a/lib/views/register.dart
+++ b/lib/views/register.dart
@@ -29,6 +29,8 @@ class _RegisterPageState extends State<RegisterPage> {
   bool _confirmPasswordVisible = false;
   bool _termsAccepted = false;
 
+  final _formKey = GlobalKey<FormState>();
+
   void _sendRegisterPayload() async {
     // empty checks
     setState(() {
@@ -189,103 +191,113 @@ class _RegisterPageState extends State<RegisterPage> {
                 ),
               ),
               const SizedBox(height: 40),
-              TextField(
-                controller: emailController,
-                keyboardType: TextInputType.text,
-                textInputAction: TextInputAction.next,
-                decoration: InputDecoration(
-                  errorText: emailError,
-                  hintText: translate('emailHint'),
-                  labelText: translate('email'),
-                  prefixIcon: const Icon(Icons.email),
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(30.0),
-                  ),
-                ),
-              ),
-              const SizedBox(height: 10),
-              TextField(
-                controller: usernameController,
-                keyboardType: TextInputType.text,
-                textInputAction: TextInputAction.next,
-                decoration: InputDecoration(
-                  errorText: usernameError,
-                  hintText: translate('usernameRegisterHint'),
-                  errorMaxLines: 4,
-                  labelText: translate('username'),
-                  prefixIcon: const Icon(Icons.person),
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(30.0),
-                  ),
-                ),
-              ),
-              const SizedBox(height: 10),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Expanded(
-                    child: TextField(
-                      controller: passwordController,
+              Form(
+                key: _formKey,
+                child: Column(
+                  children: [
+                    TextFormField(
+                      controller: emailController,
+                      keyboardType: TextInputType.text,
+                      maxLength: 256,
                       textInputAction: TextInputAction.next,
-                      obscureText: !_passwordVisible,
-                      maxLength: 128,
                       decoration: InputDecoration(
-                        errorText: passwordError,
+                        errorText: emailError,
+                        hintText: translate('emailHint'),
+                        counterText: '',
+                        labelText: translate('email'),
+                        prefixIcon: const Icon(Icons.email),
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(30.0),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    TextFormField(
+                      controller: usernameController,
+                      keyboardType: TextInputType.text,
+                      maxLength: 16,
+                      textInputAction: TextInputAction.next,
+                      decoration: InputDecoration(
+                        errorText: usernameError,
+                        hintText: translate('usernameRegisterHint'),
                         errorMaxLines: 4,
-                        counterText: '',
-                        hintText: translate('passwordHint'),
-                        labelText: translate('password'),
-                        prefixIcon: const Icon(Icons.lock),
+                        labelText: translate('username'),
+                        prefixIcon: const Icon(Icons.person),
                         border: OutlineInputBorder(
                           borderRadius: BorderRadius.circular(30.0),
                         ),
-                        suffixIcon: IconButton(
-                          icon: Icon(
-                            _passwordVisible
-                                ? Icons.visibility
-                                : Icons.visibility_off,
-                          ),
-                          onPressed: () {
-                            setState(() {
-                              _passwordVisible = !_passwordVisible;
-                            });
-                          },
-                        ),
                       ),
                     ),
-                  ),
-                  const SizedBox(width: 7.5),
-                  Expanded(
-                    child: TextField(
-                      controller: passwordConfirmController,
-                      textInputAction: TextInputAction.next,
-                      obscureText: !_confirmPasswordVisible,
-                      maxLength: 128,
-                      decoration: InputDecoration(
-                        errorText: passwordConfirmError,
-                        hintText: translate('passwordConfirmationHint'),
-                        labelText: translate('passwordConfirmation'),
-                        prefixIcon: const Icon(Icons.lock_outline),
-                        counterText: '',
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(30.0),
-                        ),
-                        suffixIcon: IconButton(
-                          icon: Icon(
-                            _confirmPasswordVisible
-                                ? Icons.visibility
-                                : Icons.visibility_off,
+                    const SizedBox(height: 10),
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Expanded(
+                          child: TextFormField(
+                            controller: passwordController,
+                            textInputAction: TextInputAction.next,
+                            obscureText: !_passwordVisible,
+                            maxLength: 128,
+                            decoration: InputDecoration(
+                              errorText: passwordError,
+                              errorMaxLines: 4,
+                              counterText: '',
+                              hintText: translate('passwordHint'),
+                              labelText: translate('password'),
+                              prefixIcon: const Icon(Icons.lock),
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(30.0),
+                              ),
+                              suffixIcon: IconButton(
+                                icon: Icon(
+                                  _passwordVisible
+                                      ? Icons.visibility
+                                      : Icons.visibility_off,
+                                ),
+                                onPressed: () {
+                                  setState(() {
+                                    _passwordVisible = !_passwordVisible;
+                                  });
+                                },
+                              ),
+                            ),
                           ),
-                          onPressed: () {
-                            setState(() {
-                              _confirmPasswordVisible = !_confirmPasswordVisible;
-                            });
-                          },
                         ),
-                      ),
+                        const SizedBox(width: 7.5),
+                        Expanded(
+                          child: TextFormField(
+                            controller: passwordConfirmController,
+                            textInputAction: TextInputAction.next,
+                            obscureText: !_confirmPasswordVisible,
+                            maxLength: 128,
+                            decoration: InputDecoration(
+                              errorText: passwordConfirmError,
+                              hintText: translate('passwordConfirmationHint'),
+                              labelText: translate('passwordConfirmation'),
+                              prefixIcon: const Icon(Icons.lock_outline),
+                              counterText: '',
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(30.0),
+                              ),
+                              suffixIcon: IconButton(
+                                icon: Icon(
+                                  _confirmPasswordVisible
+                                      ? Icons.visibility
+                                      : Icons.visibility_off,
+                                ),
+                                onPressed: () {
+                                  setState(() {
+                                    _confirmPasswordVisible = !_confirmPasswordVisible;
+                                  });
+                                },
+                              ),
+                            ),
+                          ),
+                        )
+                      ],
                     ),
-                  )
-                ],
+                  ],
+                ),
               ),
               const SizedBox(height: 50),
               Row(

--- a/lib/views/shared/password_field.dart
+++ b/lib/views/shared/password_field.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+class PasswordField extends StatefulWidget {
+  final TextEditingController controller;
+  final String? errorText;
+  final String? labelText;
+  final String? hintText;
+  final bool enabled;
+  final Iterable<String>? autofillHints;
+  final TextInputAction? textInputAction;
+  final ValueChanged<String>? onFieldSubmitted;
+  final int? maxLength;
+  final Widget? prefixIcon;
+  final int? errorMaxLines;
+  final ValueChanged<String>? onChanged;
+
+  const PasswordField({
+    super.key,
+    required this.controller,
+    this.errorText,
+    this.labelText,
+    this.hintText,
+    this.enabled = true,
+    this.autofillHints = const [AutofillHints.password],
+    this.textInputAction,
+    this.onFieldSubmitted,
+    this.maxLength,
+    this.prefixIcon = const Icon(Icons.lock),
+    this.errorMaxLines,
+    this.onChanged,
+  });
+
+  @override
+  State<PasswordField> createState() => _PasswordFieldState();
+}
+
+class _PasswordFieldState extends State<PasswordField> {
+  bool _passwordVisible = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      enabled: widget.enabled,
+      controller: widget.controller,
+      obscureText: !_passwordVisible,
+      autofillHints: widget.autofillHints,
+      textInputAction: widget.textInputAction,
+      onFieldSubmitted: widget.onFieldSubmitted,
+      onChanged: widget.onChanged,
+      maxLength: widget.maxLength,
+      decoration: InputDecoration(
+        errorText: widget.errorText,
+        errorMaxLines: widget.errorMaxLines,
+        hintText: widget.hintText,
+        labelText: widget.labelText,
+        prefixIcon: widget.prefixIcon,
+        counterText: widget.maxLength != null ? '' : null,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(30.0),
+        ),
+        suffixIcon: IconButton(
+          icon: Icon(
+            _passwordVisible ? Icons.visibility : Icons.visibility_off,
+          ),
+          onPressed: () {
+            setState(() {
+              _passwordVisible = !_passwordVisible;
+            });
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.0
+version: 1.1.1
 
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
## Description
Issues with login and resetting one's passwords included not being able to save the credentials with the device-specific password manager, because the forms weren't actually registered as forms, and non-existent "show password" buttons across several forms that required authentication.

In this Pull Request, we targeted those problems by re-writing some of the forms by generalizing some of the fields that are re-used.

## Closing Issues
By merging this P.R., the following issues should close:
- #96
- #97 

## Fixes
- Login and Register will now prompt the user to save their credentials by their devices, when registering or logging in.
- Fixed password fields not having a "show password" button in several forms